### PR TITLE
Update unit tests and add CI

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,25 @@
+name: dotnet package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Setup .NET Core SDK 5.0.x
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+          dotnet-version: '5.0.x'
+      - name: Setup .NET Core SDK 3.1.x
+        uses: actions/setup-dotnet@v1.7.2
+        with:
+          dotnet-version: '3.1.x'
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/NetStone.Test/UnitTest1.cs
+++ b/NetStone.Test/UnitTest1.cs
@@ -1,16 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using NetStone;
 using NetStone.GameData.Packs;
-using NetStone.Model.Parseables.Search;
-using NetStone.Search;
 using NetStone.Search.Character;
 using NetStone.Search.FreeCompany;
 using NetStone.StaticData;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
-using NUnit.Framework.Internal;
 using SortKind = NetStone.Search.Character.SortKind;
 
 namespace NetStone.Test
@@ -55,7 +50,7 @@ namespace NetStone.Test
             };
 
             var page = await this.lodestone.SearchCharacter(query);
-            Assert.AreEqual(3, page.NumPages);
+            Assert.AreEqual(4, page.NumPages);
             Assert.AreEqual(1, page.CurrentPage);
 
             var cResults = 0;
@@ -110,7 +105,7 @@ namespace NetStone.Test
             };
 
             var page = await this.lodestone.SearchFreeCompany(query);
-            Assert.AreEqual(4, page.NumPages);
+            Assert.AreEqual(5, page.NumPages);
             Assert.AreEqual(1, page.CurrentPage);
 
             var cResults = 0;


### PR DESCRIPTION
These tests were failing because of the amount of returned pages. I was trying to figure out if there was something that needed updating immediately for NetStone after the Lodestone update, but as far as what's covered by the tests goes they still seem to work fine otherwise.