### PR TITLE
Mark requests as nullable and expose FC server

### DIFF
--- a/NetStone/LodestoneClient.cs
+++ b/NetStone/LodestoneClient.cs
@@ -66,7 +66,7 @@ namespace NetStone
         /// </summary>
         /// <param name="id">The ID of the character.</param>
         /// <returns><see cref="LodestoneCharacter"/> class containing information about the character.</returns>
-        public async Task<LodestoneCharacter> GetCharacter(string id) => await GetParsed($"/lodestone/character/{id}/",
+        public async Task<LodestoneCharacter?> GetCharacter(string id) => await GetParsed($"/lodestone/character/{id}/",
             node => new LodestoneCharacter(this, node, this.Definitions, id));
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace NetStone
         /// </summary>
         /// <param name="id">The ID of the character.</param>
         /// <returns><see cref="CharacterClassJob"/> class containing information about the characters' classes and jobs.</returns>
-        public async Task<CharacterClassJob> GetCharacterClassJob(string id) => await GetParsed(
+        public async Task<CharacterClassJob?> GetCharacterClassJob(string id) => await GetParsed(
             $"/lodestone/character/{id}/class_job/", node => new CharacterClassJob(node, this.Definitions.ClassJob));
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace NetStone
         /// <param name="id">The ID of the character.</param>
         /// <param name="page">The number of the page that should be fetched.</param>
         /// <returns><see cref="CharacterAchievementPage"/> class containing information about the characters' achievements.</returns>
-        public async Task<CharacterAchievementPage> GetCharacterAchievement(string id, int page = 1) => await GetParsed(
+        public async Task<CharacterAchievementPage?> GetCharacterAchievement(string id, int page = 1) => await GetParsed(
             $"/lodestone/character/{id}/achievement/?page={page}",
             node => new CharacterAchievementPage(this, node, this.Definitions.Achievement, id));
 
@@ -95,7 +95,7 @@ namespace NetStone
         /// </summary>
         /// <param name="id">The ID of the character.</param>
         /// <returns><see cref="CharacterCollectable"/> class containing information about the characters' mounts.</returns>
-        public async Task<CharacterCollectable> GetCharacterMount(string id) => await GetParsed(
+        public async Task<CharacterCollectable?> GetCharacterMount(string id) => await GetParsed(
             $"/lodestone/character/{id}/mount/",
             node => new CharacterCollectable(node, this.Definitions.Mount),
             UserAgent.Mobile);
@@ -106,7 +106,7 @@ namespace NetStone
         /// </summary>
         /// <param name="id">The ID of the character.</param>
         /// <returns><see cref="CharacterCollectable"/> class containing information about the characters' minions.</returns>
-        public async Task<CharacterCollectable> GetCharacterMinion(string id) => await GetParsed(
+        public async Task<CharacterCollectable?> GetCharacterMinion(string id) => await GetParsed(
             $"/lodestone/character/{id}/minion/",
             node => new CharacterCollectable(node, this.Definitions.Minion),
             UserAgent.Mobile);
@@ -117,7 +117,7 @@ namespace NetStone
         /// <param name="query"><see cref="CharacterSearchQuery"/> object detailing search parameters</param>
         /// <param name="page">The page of search results to fetch.</param>
         /// <returns><see cref="CharacterSearchPage"/> containing search results.</returns>
-        public async Task<CharacterSearchPage> SearchCharacter(CharacterSearchQuery query, int page = 1) =>
+        public async Task<CharacterSearchPage?> SearchCharacter(CharacterSearchQuery query, int page = 1) =>
             await GetParsed($"/lodestone/character/{query.BuildQueryString()}&page={page}",
                 node => new CharacterSearchPage(this, node, this.Definitions.CharacterSearch, query));
 
@@ -130,7 +130,7 @@ namespace NetStone
         /// </summary>
         /// <param name="id">The ID of the character.</param>
         /// <returns><see cref="LodestoneFreeCompany"/> class containing information about the character.</returns>
-        public async Task<LodestoneFreeCompany> GetFreeCompany(string id) => await GetParsed(
+        public async Task<LodestoneFreeCompany?> GetFreeCompany(string id) => await GetParsed(
             $"/lodestone/freecompany/{id}/", node => new LodestoneFreeCompany(this, node, this.Definitions, id));
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace NetStone
         /// <param name="id">The ID of the free company.</param>
         /// <param name="page">The page of members to fetch.</param>
         /// <returns><see cref="FreeCompanyMembers"/> class containing information about FC members.</returns>
-        public async Task<FreeCompanyMembers> GetFreeCompanyMembers(string id, int page = 1) => await GetParsed(
+        public async Task<FreeCompanyMembers?> GetFreeCompanyMembers(string id, int page = 1) => await GetParsed(
             $"/lodestone/freecompany/{id}/member/?page={page}",
             node => new FreeCompanyMembers(this, node, this.Definitions.FreeCompanyMembers, id));
 
@@ -149,7 +149,7 @@ namespace NetStone
         /// <param name="query"><see cref="FreeCompanySearchPage"/> object detailing search parameters.</param>
         /// <param name="page">The page of search results to fetch.</param>
         /// <returns><see cref="FreeCompanySearchPage"/> containing search results.</returns>
-        public async Task<FreeCompanySearchPage> SearchFreeCompany(FreeCompanySearchQuery query, int page = 1) =>
+        public async Task<FreeCompanySearchPage?> SearchFreeCompany(FreeCompanySearchQuery query, int page = 1) =>
             await GetParsed($"/lodestone/freecompany/{query.BuildQueryString()}&page={page}",
                 node => new FreeCompanySearchPage(this, node, this.Definitions.FreeCompanySearch, query));
 
@@ -163,7 +163,7 @@ namespace NetStone
         /// <param name="createParseable">Func creating the LodestoneParseable.</param>
         /// <param name="agent">The user agent to use for the request.</param>
         /// <returns>The instantiated LodestoneParseable in case of success.</returns>
-        private async Task<T> GetParsed<T>(string url, Func<HtmlNode, T> createParseable, UserAgent agent = UserAgent.Desktop) where T: LodestoneParseable
+        private async Task<T?> GetParsed<T>(string url, Func<HtmlNode, T?> createParseable, UserAgent agent = UserAgent.Desktop) where T: LodestoneParseable
         {
             var request = new HttpRequestMessage(HttpMethod.Get, url);
 

--- a/NetStone/Model/Parseables/Character/Achievement/CharacterAchievementPage.cs
+++ b/NetStone/Model/Parseables/Character/Achievement/CharacterAchievementPage.cs
@@ -105,7 +105,7 @@ namespace NetStone.Model.Parseables.Character.Achievement
             this.numPagesVal = int.Parse(results["NumPages"].Value);
         }
         
-        public async Task<CharacterAchievementPage> GetNextPage()
+        public async Task<CharacterAchievementPage?> GetNextPage()
         {
             if (!HasResults)
                 return null;

--- a/NetStone/Model/Parseables/Character/FreeCompanySocialGroup.cs
+++ b/NetStone/Model/Parseables/Character/FreeCompanySocialGroup.cs
@@ -21,6 +21,6 @@ namespace NetStone.Model.Parseables.Character
         /// Fetch the full details of this FC.
         /// </summary>
         /// <returns><see cref="LodestoneFreeCompany"/> object containing all details of the free company.</returns>
-        public async Task<LodestoneFreeCompany> GetDetails() => await this.client.GetFreeCompany(this.Id);
+        public async Task<LodestoneFreeCompany?> GetDetails() => await this.client.GetFreeCompany(this.Id);
     }
 }

--- a/NetStone/Model/Parseables/Character/LodestoneCharacter.cs
+++ b/NetStone/Model/Parseables/Character/LodestoneCharacter.cs
@@ -147,25 +147,25 @@ namespace NetStone.Model.Parseables.Character
         /// Fetch more information about this character's classes and jobs(level, exp, unlocked, etc.).
         /// </summary>
         /// <returns><see cref="CharacterClassJob"/> object holding this information.</returns>
-        public async Task<CharacterClassJob> GetClassJobInfo() => await this.client.GetCharacterClassJob(this.charId);
+        public async Task<CharacterClassJob?> GetClassJobInfo() => await this.client.GetCharacterClassJob(this.charId);
 
         /// <summary>
         /// Fetch more information about this character's unlocked achievements.
         /// </summary>
         /// <returns><see cref="CharacterAchievementPage"/> object holding this information.</returns>
-        public async Task<CharacterAchievementPage> GetAchievement() => await this.client.GetCharacterAchievement(this.charId);
+        public async Task<CharacterAchievementPage?> GetAchievement() => await this.client.GetCharacterAchievement(this.charId);
 
         /// <summary>
         /// Fetch more information about this character's unlocked mounts.
         /// </summary>
         /// <returns><see cref="CharacterCollectable"/> object holding this information.</returns>
-        public async Task<CharacterCollectable> GetMounts() => await this.client.GetCharacterMount(this.charId);
+        public async Task<CharacterCollectable?> GetMounts() => await this.client.GetCharacterMount(this.charId);
 
         /// <summary>
         /// Fetch more information about this character's unlocked minions.
         /// </summary>
         /// <returns><see cref="CharacterCollectable"/> object holding this information.</returns>
-        public async Task<CharacterCollectable> GetMinions() => await this.client.GetCharacterMinion(this.charId);
+        public async Task<CharacterCollectable?> GetMinions() => await this.client.GetCharacterMinion(this.charId);
 
         /// <summary>
         /// String representation of this character.

--- a/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
+++ b/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
@@ -60,6 +60,8 @@ namespace NetStone.Model.Parseables.FreeCompany
 
         public FreeCompanyReputation Reputation => new FreeCompanyReputation(this.RootNode, this.reputationDefinition);
 
+        public string World => Parse(this.fcDefinition.Server);
+
         public async Task<FreeCompanyMembers?> GetMembers() => await this.client.GetFreeCompanyMembers(this.Id);
     }
 }

--- a/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
+++ b/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
@@ -60,6 +60,6 @@ namespace NetStone.Model.Parseables.FreeCompany
 
         public FreeCompanyReputation Reputation => new FreeCompanyReputation(this.RootNode, this.reputationDefinition);
 
-        public async Task<FreeCompanyMembers> GetMembers() => await this.client.GetFreeCompanyMembers(this.Id);
+        public async Task<FreeCompanyMembers?> GetMembers() => await this.client.GetFreeCompanyMembers(this.Id);
     }
 }

--- a/NetStone/Model/Parseables/FreeCompany/Members/FreeCompanyMembers.cs
+++ b/NetStone/Model/Parseables/FreeCompany/Members/FreeCompanyMembers.cs
@@ -91,7 +91,7 @@ namespace NetStone.Model.Parseables.FreeCompany.Members
             this.numPagesVal = int.Parse(results["NumPages"].Value);
         }
 
-        public async Task<FreeCompanyMembers> GetNextPage()
+        public async Task<FreeCompanyMembers?> GetNextPage()
         {
             if (CurrentPage == NumPages)
                 return null;

--- a/NetStone/Model/Parseables/Search/Character/CharacterSearchEntry.cs
+++ b/NetStone/Model/Parseables/Search/Character/CharacterSearchEntry.cs
@@ -20,7 +20,7 @@ namespace NetStone.Model.Parseables.Search.Character
 
         public string Id => ParseHrefId(this.definition.Id);
 
-        public async Task<LodestoneCharacter> GetCharacter() => await this.client.GetCharacter(this.Id);
+        public async Task<LodestoneCharacter?> GetCharacter() => await this.client.GetCharacter(this.Id);
 
         public override string ToString() => Name;
     }

--- a/NetStone/Model/Parseables/Search/Character/CharacterSearchPage.cs
+++ b/NetStone/Model/Parseables/Search/Character/CharacterSearchPage.cs
@@ -94,7 +94,7 @@ namespace NetStone.Model.Parseables.Search.Character
             this.numPagesVal = int.Parse(results["NumPages"].Value);
         }
         
-        public async Task<CharacterSearchPage> GetNextPage()
+        public async Task<CharacterSearchPage?> GetNextPage()
         {
             if (!HasResults)
                 return null;

--- a/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchEntry.cs
+++ b/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchEntry.cs
@@ -58,7 +58,7 @@ namespace NetStone.Model.Parseables.Search.FreeCompany
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        public async Task<LodestoneFreeCompany> GetFreeCompany() => await this.client.GetFreeCompany(this.Id);
+        public async Task<LodestoneFreeCompany?> GetFreeCompany() => await this.client.GetFreeCompany(this.Id);
 
         public override string ToString() => Name;
     }

--- a/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchPage.cs
+++ b/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchPage.cs
@@ -93,7 +93,7 @@ namespace NetStone.Model.Parseables.Search.FreeCompany
             this.numPagesVal = int.Parse(results["NumPages"].Value);
         }
 
-        public async Task<FreeCompanySearchPage> GetNextPage()
+        public async Task<FreeCompanySearchPage?> GetNextPage()
         {
             if (!HasResults)
                 return null;


### PR DESCRIPTION
The helper function used to fetch data from Lodestone would return `null` if a 404 is returned, so it is more accurate to mark these as nullable.

I also exposed the `Server` property as `World` for FCs.