### PR TITLE
Fix character mount and minion search

### DIFF
--- a/NetStone/Definitions/Model/Character/CharacterCollectableDefinition.cs
+++ b/NetStone/Definitions/Model/Character/CharacterCollectableDefinition.cs
@@ -5,9 +5,36 @@ using Newtonsoft.Json;
 
 namespace NetStone.Definitions.Model.Character
 {
-    public class CharacterCollectableDefinition : IDefinition
+    public interface CharacterCollectableDefinition : IDefinition
     {
-        [JsonProperty("LIST")] public DefinitionsPack List { get; set; }
+        public CollectableNodeDefinition GetDefinitions();
+    }
+
+    public class CharacterMountDefinition : CharacterCollectableDefinition
+    {
+        [JsonProperty("MOUNTS")]
+        public CollectableNodeDefinition Mounts { get; set; }
+
+        public CollectableNodeDefinition GetDefinitions()
+        {
+            return Mounts;
+        }
+    }
+
+    public class CharacterMinionDefinition : CharacterCollectableDefinition
+    {
+        [JsonProperty("MINIONS")]
+        public CollectableNodeDefinition Minions { get; set; }
+
+        public CollectableNodeDefinition GetDefinitions()
+        {
+            return Minions;
+        }
+    }
+    
+    public class CollectableNodeDefinition
+    {
+        [JsonProperty("ROOT")] public DefinitionsPack Root { get; set; }
 
         [JsonProperty("NAME")] public DefinitionsPack Name { get; set; }
     }

--- a/NetStone/Definitions/XivApiDefinitionsContainer.cs
+++ b/NetStone/Definitions/XivApiDefinitionsContainer.cs
@@ -31,8 +31,8 @@ namespace NetStone.Definitions
             this.Gear = await GetDefinition<CharacterGearDefinition>("profile/gearset.json");
             this.Attributes = await GetDefinition<CharacterAttributesDefinition>("profile/attributes.json");
             this.Achievement = await GetDefinition<PagedDefinition>("profile/achievements.json");
-            this.Mount = await GetDefinition<CharacterCollectableDefinition>("profile/mount.json");
-            this.Minion = await GetDefinition<CharacterCollectableDefinition>("profile/minion.json");
+            this.Mount = await GetDefinition<CharacterMountDefinition>("profile/mount.json");
+            this.Minion = await GetDefinition<CharacterMinionDefinition>("profile/minion.json");
 
             this.FreeCompany = await GetDefinition<FreeCompanyDefinition>("freecompany/freecompany.json");
             this.FreeCompanyFocus = await GetDefinition<FreeCompanyFocusDefinition>("freecompany/focus.json");

--- a/NetStone/Model/LodestoneParseable.cs
+++ b/NetStone/Model/LodestoneParseable.cs
@@ -36,7 +36,10 @@ namespace NetStone.Model
         /// </summary>
         /// <param name="pack">Definition of the node.</param>
         /// <returns>All ChildNodes.</returns>
-        protected HtmlNode[] QueryChildNodes(DefinitionsPack pack) => QueryNode(pack)?.ChildNodes.Where(x => x.Name != "#text").ToArray();
+        protected HtmlNode[] QueryChildNodes(DefinitionsPack pack) => this.RootNode
+            .QuerySelectorAll(pack.Selector)
+            .Where(x => x.Name != "#text")
+            .ToArray();
 
         protected HtmlNode[] QueryContainer(PagedDefinition pagedDefinition)
         {

--- a/NetStone/Model/Parseables/Character/Collectable/CharacterCollectable.cs
+++ b/NetStone/Model/Parseables/Character/Collectable/CharacterCollectable.cs
@@ -34,7 +34,7 @@ namespace NetStone.Model.Parseables.Character.Collectable
 
         private void ParseCollectables()
         {
-            var nodes = QueryChildNodes(this.definition.List);
+            var nodes = QueryChildNodes(this.definition.GetDefinitions().Root);
 
             this.parsedResults = new CharacterCollectableEntry[nodes.Length];
             for (var i = 0; i < this.parsedResults.Length; i++)

--- a/NetStone/Model/Parseables/Character/Collectable/CharacterCollectableEntry.cs
+++ b/NetStone/Model/Parseables/Character/Collectable/CharacterCollectableEntry.cs
@@ -19,7 +19,7 @@ namespace NetStone.Model.Parseables.Character.Collectable
         /// <summary>
         /// The name of this collectable.
         /// </summary>
-        public string Name => Parse(this.definition.Name);
+        public string Name => Parse(this.definition.GetDefinitions().Name);
 
         /// <summary>
         /// The string representation of this collectable.


### PR DESCRIPTION
Character mount and minion searches were using an outdated selector. These changes allow both to be parsed again properly.