### PR TITLE
Nullability fixes, add active class job icon

### DIFF
--- a/NetStone/Model/Parseables/Character/CharacterAttributes.cs
+++ b/NetStone/Model/Parseables/Character/CharacterAttributes.cs
@@ -93,17 +93,17 @@ public class CharacterAttributes : LodestoneParseable
     /// <summary>
     /// This characters' Spell Speed value.
     /// </summary>
-    public int SpellSpeed => int.Parse(Parse(this.definition.SpellSpeed));
+    public int? SpellSpeed => int.TryParse(Parse(this.definition.SpellSpeed), out var result) ? result : null;
 
     /// <summary>
     /// This characters' Tenacity value.
     /// </summary>
-    public int Tenacity => int.Parse(Parse(this.definition.Tenacity));
+    public int? Tenacity => int.TryParse(Parse(this.definition.Tenacity), out var result) ? result : null;
 
     /// <summary>
     /// This characters' Piety value.
     /// </summary>
-    public int Piety => int.Parse(Parse(this.definition.Piety));
+    public int? Piety => int.TryParse(Parse(this.definition.Piety), out var result) ? result : null;
 
     /// <summary>
     /// This characters' HP value.

--- a/NetStone/Model/Parseables/Character/LodestoneCharacter.cs
+++ b/NetStone/Model/Parseables/Character/LodestoneCharacter.cs
@@ -43,7 +43,10 @@ public class LodestoneCharacter : LodestoneParseable
 
     #region Properties
 
-    //public string ActiveClassJob => ParseInnerText(this.charDefinition.ActiveClassJob);
+    /// <summary>
+    /// Icon of current active ClassJob.
+    /// </summary>
+    public string ActiveClassJobIcon => ParseInnerText(this.charDefinition.ActiveClassJob);
 
     /// <summary>
     /// Level of the current active ClassJob.

--- a/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
+++ b/NetStone/Model/Parseables/FreeCompany/LodestoneFreeCompany.cs
@@ -80,12 +80,12 @@ public class LodestoneFreeCompany : LodestoneParseable
     /// <summary>
     /// Monthly ranking
     /// </summary>
-    public int RankingMonthly => int.Parse(Parse(this.fcDefinition.Ranking.Monthly));
+    public int? RankingMonthly => int.TryParse(Parse(fcDefinition.Ranking.Monthly), out var result) ? result : null;
 
     /// <summary>
     /// Weekly ranking
     /// </summary>
-    public int RankingWeekly => int.Parse(Parse(this.fcDefinition.Ranking.Weekly));
+    public int? RankingWeekly => int.TryParse(Parse(fcDefinition.Ranking.Weekly), out var result) ? result : null;
 
     /// <summary>
     /// Recruitment status

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -2514,6 +2514,11 @@
             <param name="container">The <see cref="T:NetStone.Definitions.DefinitionsContainer"/> holding definitions to be used to access data.</param>
             <param name="charId">The ID of the character.</param>
         </member>
+        <member name="P:NetStone.Model.Parseables.Character.LodestoneCharacter.ActiveClassJobIcon">
+            <summary>
+            Icon of current active ClassJob.
+            </summary>
+        </member>
         <member name="P:NetStone.Model.Parseables.Character.LodestoneCharacter.ActiveClassJobLevel">
             <summary>
             Level of the current active ClassJob.


### PR DESCRIPTION
Hey there, I've been using NetStone for a project of mine for a bit. I've noticed some user and free company properties can be null under some circumstances, and the parser fails as a result.

This can happen when a character is a disciple of hand/land instead of a battle job, and if a free company fails to hit the monthly/weekly rankings at all.

I've also had to use job icons myself, so I've added that property back in and adjusted its name. It was commented out.