### PR TITLE
Parse item levels of gear

### DIFF
--- a/NetStone.Test/Tests.cs
+++ b/NetStone.Test/Tests.cs
@@ -175,9 +175,9 @@ public class Tests
         Assert.AreEqual("Immortal Flames", fc.GrandCompany);
         Assert.AreEqual("Bedge Lords", fc.Name);
         Assert.AreEqual("«BEDGE»", fc.Tag);
-        Assert.AreEqual("Friendly and active FC with 24/7 buffs, fun events and a cozy Large in Goblet. LF new Bedgers to join us! Check our Lodestone or come & chat for details! \u2665", fc.Slogan);
+        Assert.AreEqual("Friendly FC with 24/7 buffs, events and a large FC house in Goblet. LF more new amiable Bedgers to join us! Check our Lodestone & come chat for details.", fc.Slogan);
         Assert.AreEqual(new DateTime(2022, 12, 04, 19, 47, 07), fc.Formed);
-        Assert.GreaterOrEqual(fc.ActiveMemberCount, 60);
+        Assert.GreaterOrEqual(fc.ActiveMemberCount, 50);
         Assert.AreEqual(30, fc.Rank);
 
         //Reputation
@@ -365,7 +365,7 @@ public class Tests
         
         //Gear
         var gear = chara.Gear;
-        Assert.AreEqual($"Mandervillous Wings", gear.Mainhand?.ItemName);
+        Assert.AreEqual("Mandervillous Wings", gear.Mainhand?.ItemName);
         Assert.IsFalse(gear.Mainhand.IsHq);
         Assert.AreEqual("Mandervillous Wings", gear.Mainhand.StrippedItemName);
         
@@ -376,6 +376,7 @@ public class Tests
         Assert.IsNull(gear.Offhand);
 
         Assert.AreEqual("Augmented Credendum Circlet of Healing", gear.Head?.ItemName);
+        Assert.AreEqual(660, gear.Head?.ItemLevel);
         Assert.NotNull(gear.Head.ItemDatabaseLink);
         Assert.AreEqual("The Emperor's New Hat",gear.Head.GlamourName);
         Assert.NotNull(gear.Head.GlamourDatabaseLink);
@@ -383,27 +384,35 @@ public class Tests
         Assert.AreEqual("Heavens' Eye Materia X",gear.Head.Materia[1]);
         
         Assert.AreEqual("Ascension Robe of Healing", gear.Body?.ItemName);
+        Assert.AreEqual(660, gear.Body?.ItemLevel);
 
         Assert.AreEqual("Augmented Credendum Gauntlets of Healing", gear.Hands?.ItemName);
+        Assert.AreEqual(660, gear.Hands?.ItemLevel);
 
         Assert.AreEqual("Augmented Credendum Hose of Healing", gear.Legs?.ItemName);
+        Assert.AreEqual(660, gear.Legs?.ItemLevel);
 
         Assert.AreEqual("Ascension Sandals of Healing", gear.Feet?.ItemName);
+        Assert.AreEqual(660, gear.Feet?.ItemLevel);
 
         Assert.AreEqual("Augmented Credendum Earrings of Healing", gear.Earrings?.ItemName);
+        Assert.AreEqual(660, gear.Earrings?.ItemLevel);
 
         Assert.AreEqual("Ascension Necklace of Healing", gear.Necklace?.ItemName);
+        Assert.AreEqual(660, gear.Necklace?.ItemLevel);
 
         Assert.AreEqual("Ascension Bracelet of Healing", gear.Bracelets?.ItemName);
+        Assert.AreEqual(660, gear.Bracelets?.ItemLevel);
         
         Assert.AreEqual("Ascension Ring of Healing", gear.Ring1?.ItemName);
+        Assert.AreEqual(660, gear.Ring1?.ItemLevel);
         Assert.IsFalse(gear.Ring1.IsHq);
         
         Assert.AreEqual("Augmented Credendum Ring of Healing", gear.Ring2?.ItemName);
+        Assert.AreEqual(660, gear.Ring2?.ItemLevel);
         
         Assert.AreEqual("Soul of the Sage", gear.Soulcrystal?.ItemName);
-
-
+        
         //Classes/Jobs
         var classJob = await chara.GetClassJobInfo();
         Assert.NotNull(classJob);

--- a/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
+++ b/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
@@ -72,6 +72,12 @@ public class GearEntryDefinition
     /// </summary>
     [JsonProperty("CREATOR_NAME")]
     public DefinitionsPack CreatorName { get; set; }
+    
+    /// <summary>
+    /// Item level of the item
+    /// </summary>
+    [JsonProperty("ITEM_LEVEL")]
+    public DefinitionsPack ItemLevel { get; set; }
 }
 
 /// <summary>

--- a/NetStone/Model/Parseables/Character/Gear/GearEntry.cs
+++ b/NetStone/Model/Parseables/Character/Gear/GearEntry.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using HtmlAgilityPack;
 using NetStone.Definitions.Model.Character;
 using NetStone.GameData;
@@ -84,6 +85,13 @@ public class GearEntry : LodestoneParseable, IOptionalParseable<GearEntry>
     /// Name of this item's crafter.
     /// </summary>
     public string CreatorName => Parse(this.definition.CreatorName);
+    
+    /// <summary>
+    /// Item level of this item
+    /// </summary>
+    public int ItemLevel => int.TryParse(Parse(definition.ItemLevel).Split(' ').LastOrDefault(), out var itemLevel)
+        ? itemLevel
+        : 0;
 
     /// <summary>
     /// Indicating whether the item slot has an item equipped or not.

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -883,11 +883,6 @@
             Homeworld
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.Character.CharacterSearchEntryDefinition.Root">
-            <summary>
-            Root node
-            </summary>
-        </member>
         <member name="T:NetStone.Definitions.Model.FreeCompany.EstateDefinition">
             <summary>
             Definitions for FC estate
@@ -1084,11 +1079,6 @@
             Definition for one FC member
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.FreeCompany.FreeCompanyMembersEntryDefinition.Root">
-            <summary>
-            Root node of entry
-            </summary>
-        </member>
         <member name="P:NetStone.Definitions.Model.FreeCompany.FreeCompanyMembersEntryDefinition.Avatar">
             <summary>
             Avatar of member character
@@ -1212,11 +1202,6 @@
         <member name="P:NetStone.Definitions.Model.FreeCompany.FreeCompanySearchEntryDefinition.Formed">
             <summary>
             Formation date
-            </summary>
-        </member>
-        <member name="P:NetStone.Definitions.Model.FreeCompany.FreeCompanySearchEntryDefinition.Root">
-            <summary>
-            Root node
             </summary>
         </member>
         <member name="T:NetStone.Definitions.Model.IconLayersDefinition">
@@ -1389,32 +1374,32 @@
             Collection of Uris for which the definition packs are valid
             </summary>
         </member>
-        <member name="T:NetStone.Definitions.Model.PagedDefinition">
+        <member name="T:NetStone.Definitions.Model.PagedDefinition`1">
             <summary>
             Base definition for paged results
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.PagedDefinition.Root">
+        <member name="P:NetStone.Definitions.Model.PagedDefinition`1.Root">
             <summary>
             Root node
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.PagedDefinition.Entry">
+        <member name="P:NetStone.Definitions.Model.PagedDefinition`1.Entry">
             <summary>
             Definition for one entry
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.PagedDefinition.PageInfo">
+        <member name="P:NetStone.Definitions.Model.PagedDefinition`1.PageInfo">
             <summary>
             Info about pages
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.PagedDefinition.ListNextButton">
+        <member name="P:NetStone.Definitions.Model.PagedDefinition`1.ListNextButton">
             <summary>
             Button for next page
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.PagedDefinition.NoResultsFound">
+        <member name="P:NetStone.Definitions.Model.PagedDefinition`1.NoResultsFound">
             <summary>
             DEfinition for node for empty results
             </summary>
@@ -1741,7 +1726,7 @@
             <param name="pack">Definition of the node.</param>
             <returns>All ChildNodes.</returns>
         </member>
-        <member name="M:NetStone.Model.LodestoneParseable.QueryContainer(NetStone.Definitions.Model.PagedDefinition)">
+        <member name="M:NetStone.Model.LodestoneParseable.QueryContainer``1(NetStone.Definitions.Model.PagedDefinition{``0})">
             <summary>
             Get a list of root nodes for entries of this paged list.
             Throws <see cref="T:System.ArgumentException"/> if definition does not contain a entry definition
@@ -1899,7 +1884,7 @@
             <param name="client">Lodestone client instance</param>
             <param name="rootNode">Root node of the achievement page</param>
             <param name="definition">Parse definition pack</param>
-            <param name="charId">Id of the character</param>
+            <param name="charId">ID of the character</param>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.Achievement.CharacterAchievementPage.TotalAchievements">
             <summary>
@@ -3109,7 +3094,7 @@
             Information about a Free Company's members
             </summary>
         </member>
-        <member name="M:NetStone.Model.Parseables.FreeCompany.Members.FreeCompanyMembers.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition,System.String)">
+        <member name="M:NetStone.Model.Parseables.FreeCompany.Members.FreeCompanyMembers.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition{NetStone.Definitions.Model.FreeCompany.FreeCompanyMembersEntryDefinition},System.String)">
             <summary>
             Constructs member list
             </summary>
@@ -3235,7 +3220,7 @@
             Models character search results
             </summary>
         </member>
-        <member name="M:NetStone.Model.Parseables.Search.Character.CharacterSearchPage.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition,NetStone.Search.Character.CharacterSearchQuery)">
+        <member name="M:NetStone.Model.Parseables.Search.Character.CharacterSearchPage.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition{NetStone.Definitions.Model.Character.CharacterSearchEntryDefinition},NetStone.Search.Character.CharacterSearchQuery)">
             <summary>
             Constructs character search results
             </summary>
@@ -3340,7 +3325,7 @@
             Models Free Company search results
             </summary>
         </member>
-        <member name="M:NetStone.Model.Parseables.Search.FreeCompany.FreeCompanySearchPage.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition,NetStone.Search.FreeCompany.FreeCompanySearchQuery)">
+        <member name="M:NetStone.Model.Parseables.Search.FreeCompany.FreeCompanySearchPage.#ctor(NetStone.LodestoneClient,HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.PagedDefinition{NetStone.Definitions.Model.FreeCompany.FreeCompanySearchEntryDefinition},NetStone.Search.FreeCompany.FreeCompanySearchQuery)">
             <summary>
             Constructs Free Company Search results
             </summary>

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -753,6 +753,11 @@
             Name of creator/crafter of this item (if applicable)
             </summary>
         </member>
+        <member name="P:NetStone.Definitions.Model.Character.GearEntryDefinition.ItemLevel">
+            <summary>
+            Item level of the item
+            </summary>
+        </member>
         <member name="T:NetStone.Definitions.Model.Character.SoulcrystalEntryDefinition">
             <summary>
             Definition for Soul Crystal slot
@@ -2601,6 +2606,11 @@
         <member name="P:NetStone.Model.Parseables.Character.Gear.GearEntry.CreatorName">
             <summary>
             Name of this item's crafter.
+            </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.GearEntry.ItemLevel">
+            <summary>
+            Item level of this item
             </summary>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.Gear.GearEntry.Exists">


### PR DESCRIPTION
Item levels already had CSS selectors, they were just missing from NetStone. Parsing is a little whack since they're parsed as "Item Level 123", so I had to split the string to only parse "123" as an int.