### PR TITLE
Add disciple of hand/land attributes to CharacterAttributes

### DIFF
--- a/NetStone/Model/Parseables/Character/CharacterAttributes.cs
+++ b/NetStone/Model/Parseables/Character/CharacterAttributes.cs
@@ -83,16 +83,19 @@ public class CharacterAttributes : LodestoneParseable
     /// <summary>
     /// This characters' Attack Magic Potency value.
     /// </summary>
-    public int AttackMagicPotency => int.Parse(Parse(this.definition.AttackMagicPotency));
+    /// <remarks>This value is only set for disciples of war/magic.</remarks>
+    public int? AttackMagicPotency => MpGpCpParameterName == "MP" ? int.Parse(Parse(this.definition.AttackMagicPotency)) : null;
 
     /// <summary>
     /// This characters' Healing Magic Potency value.
     /// </summary>
-    public int HealingMagicPotency => int.Parse(Parse(this.definition.HealingMagicPotency));
+    /// <remarks>This value is only set for disciples of war/magic.</remarks>
+    public int? HealingMagicPotency => MpGpCpParameterName == "MP" ? int.Parse(Parse(this.definition.HealingMagicPotency)) : null;
 
     /// <summary>
     /// This characters' Spell Speed value.
     /// </summary>
+    /// <remarks>This value is only set for disciples of war/magic.</remarks>
     public int? SpellSpeed => int.TryParse(Parse(this.definition.SpellSpeed), out var result) ? result : null;
 
     /// <summary>
@@ -104,6 +107,30 @@ public class CharacterAttributes : LodestoneParseable
     /// This characters' Piety value.
     /// </summary>
     public int? Piety => int.TryParse(Parse(this.definition.Piety), out var result) ? result : null;
+
+    /// <summary>
+    /// This characters' Craftmanship value.
+    /// </summary>
+    /// <remarks>This value is only set for disciples of the hand.</remarks>
+    public int? Craftmanship => MpGpCpParameterName == "CP" ? AttackMagicPotencyValue : null;
+    
+    /// <summary>
+    /// This characters' Control value.
+    /// </summary>
+    /// <remarks>This value is only set for disciples of the hand.</remarks>
+    public int? Control => MpGpCpParameterName == "CP" ? HealingMagicPotencyValue : null;
+
+    /// <summary>
+    /// This characters' Gathering value.
+    /// </summary>
+    /// <remarks>This value is only set for disciples of the land.</remarks>
+    public int? Gathering => MpGpCpParameterName == "GP" ? AttackMagicPotencyValue : null;
+    
+    /// <summary>
+    /// This characters' Perception value.
+    /// </summary>
+    /// <remarks>This value is only set for disciples of the land.</remarks>
+    public int? Perception => MpGpCpParameterName == "GP" ? HealingMagicPotencyValue : null;
 
     /// <summary>
     /// This characters' HP value.
@@ -119,4 +146,8 @@ public class CharacterAttributes : LodestoneParseable
     /// Value indicating which of MP, GP, or CP is indicated by <see cref="MpGpCp"/>.
     /// </summary>
     public string MpGpCpParameterName => Parse(this.definition.MpGpCpParameterName);
+    
+    private int AttackMagicPotencyValue => int.Parse(Parse(this.definition.AttackMagicPotency));
+    
+    private int HealingMagicPotencyValue => int.Parse(Parse(this.definition.HealingMagicPotency));
 }

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -2001,16 +2001,19 @@
             <summary>
             This characters' Attack Magic Potency value.
             </summary>
+            <remarks>This value is only set for disciples of war/magic.</remarks>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.HealingMagicPotency">
             <summary>
             This characters' Healing Magic Potency value.
             </summary>
+            <remarks>This value is only set for disciples of war/magic.</remarks>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.SpellSpeed">
             <summary>
             This characters' Spell Speed value.
             </summary>
+            <remarks>This value is only set for disciples of war/magic.</remarks>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Tenacity">
             <summary>
@@ -2021,6 +2024,30 @@
             <summary>
             This characters' Piety value.
             </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Craftmanship">
+            <summary>
+            This characters' Craftmanship value.
+            </summary>
+            <remarks>This value is only set for disciples of the hand.</remarks>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Control">
+            <summary>
+            This characters' Control value.
+            </summary>
+            <remarks>This value is only set for disciples of the hand.</remarks>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Gathering">
+            <summary>
+            This characters' Gathering value.
+            </summary>
+            <remarks>This value is only set for disciples of the land.</remarks>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Perception">
+            <summary>
+            This characters' Perception value.
+            </summary>
+            <remarks>This value is only set for disciples of the land.</remarks>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.CharacterAttributes.Hp">
             <summary>


### PR DESCRIPTION
Currently, attributes in CharacterAttributes are tailored towards disciples of war/magic. This was causing parsing errors when a character was a disciple of hand/land, though that was fixed by making missing properties nullable.

The problem now was that CSS selectors go by hierarchy, and the "Mental Properties" table on the Lodestone is missing for crafters and gatherers entirely. As a result, craftmanship+control / gathering+perception were parsed into the AttackMagicPotency and HealingMagicPotency properties.

User code could then work around this issue with a switch or similar depending on the MpGpCpParameterName value, retrieving AttackMagicPotency when trying to read Craftmanship. This wasn't great, so I've expanded the CharacterAttributes class to include crafter and gatherer attributes, and return them or null depending on whether the character is a disciple of war/magic, hand, or land.

This will now return null for AttackMagicPotency and HealingMagicPotency when the character isn't a disciple of war/magic, potentially being a breaking change. If someone already used this workaround before, they'll have to adjust their code to use the new properties.

We could also always return values for AttackMagicPotency and HealingMagicPotency as before, but they'd be completely wrong values for disciples of hand/land since they don't exist in those cases.