### PR TITLE
Add properties for FC rank and icon

### DIFF
--- a/NetStone/Definitions/Model/FreeCompany/FreeCompanyMembersEntryDefinition.cs
+++ b/NetStone/Definitions/Model/FreeCompany/FreeCompanyMembersEntryDefinition.cs
@@ -38,6 +38,18 @@ public class FreeCompanyMembersEntryDefinition : PagedEntryDefinition
     public DefinitionsPack RankIcon { get; set; }
 
     /// <summary>
+    /// Free company rank
+    /// </summary>
+    [JsonProperty("FC_RANK")]
+    public DefinitionsPack FreeCompanyRank { get; set; }
+
+    /// <summary>
+    /// FC rank icon
+    /// </summary>
+    [JsonProperty("FC_RANK_ICON")]
+    public DefinitionsPack FreeCompanyRankIcon { get; set; }
+
+    /// <summary>
     /// Homeworld
     /// </summary>
     [JsonProperty("SERVER")]

--- a/NetStone/Model/Parseables/FreeCompany/Members/FreeCompanyMembersEntry.cs
+++ b/NetStone/Model/Parseables/FreeCompany/Members/FreeCompanyMembersEntry.cs
@@ -38,6 +38,16 @@ public class FreeCompanyMembersEntry : LodestoneParseable
     public Uri? RankIcon => ParseImageSource(this.definition.RankIcon);
 
     /// <summary>
+    /// Rank with character's Free Company
+    /// </summary>
+    public string FreeCompanyRank => Parse(this.definition.FreeCompanyRank);
+
+    /// <summary>
+    /// Icon representing <see cref="FreeCompanyRank"/>
+    /// </summary>
+    public Uri? FreeCompanyRankIcon => ParseImageSource(this.definition.FreeCompanyRankIcon);
+
+    /// <summary>
     /// Home world
     /// </summary>
     public string Server => ParseRegex(this.definition.Server)["World"].Value;


### PR DESCRIPTION
Hello! First PR here, please don't hesitate to point out issues or ask for revisions.

This PR adds properties for FC rank and the corresponding FC rank icon based on the selectors that are already available in lodestone-css-selectors: https://github.com/xivapi/lodestone-css-selectors/blob/main/freecompany/members.json. 

I did some testing locally and was able to pull back these fields without issue. A pal of mine made a similar change on the go side that has been merged in over there, too: https://github.com/xivapi/godestone/pull/27. I was torn between using consistent naming with the go repo or sticking to [MSFT conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/identifier-names#naming-conventions) in regards to naming the rank variable "FCRank" or "FreeCompanyRank". Happy to leave the decision up to maintainers.

I figured that renaming Rank and RankIcon to GrandCompanyRank and GrandCompanyRankIcon would be a breaking change that you wouldn't want to introduce with this PR - let me know if there's anything you'd like me to do on that topic. 

Thank you!