### PR TITLE
Fix parsing of "active" attribute during Free Company search

### DIFF
--- a/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchEntry.cs
+++ b/NetStone/Model/Parseables/Search/FreeCompany/FreeCompanySearchEntry.cs
@@ -59,9 +59,9 @@ public class FreeCompanySearchEntry : LodestoneParseable
     public ActiveTimes Active => Parse(this.definition.Active) switch
     {
         "Always" => ActiveTimes.Always,
-        "Weekends Only" => ActiveTimes.WeekendsOnly,
-        "Weekdays Only" => ActiveTimes.WeekdaysOnly,
-        "Not specified" => ActiveTimes.All,
+        "Weekends" => ActiveTimes.WeekendsOnly,
+        "Weekdays" => ActiveTimes.WeekdaysOnly,
+        "Not" => ActiveTimes.All, // 'Not Specified' is being split up by CSS selector
         _ => throw new ArgumentOutOfRangeException(),
     };
 


### PR DESCRIPTION
Searching for free companies usually crashes as their "active" state isn't parsed correctly.

The Lodestone displays "Weekends Only" and "Weekdays Only" in the search dropdown, but in the results list, it's just "Weekends" and "Weekdays".

"Not specified" is a bit special as that's the only status displayed as two words. The CSS selector splits the string, so only "Not" ends up in NetStone.