### PR TITLE
Do not silently swallow exceptions while parsing

### DIFF
--- a/NetStone/LodestoneClient.cs
+++ b/NetStone/LodestoneClient.cs
@@ -254,16 +254,7 @@ public class LodestoneClient : IDisposable
                 throw new ArgumentOutOfRangeException(nameof(agent), agent, null);
         }
 
-        HttpResponseMessage? response;
-        try
-        {
-            response = await this.client.SendAsync(request);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
-        {
-            return null;
-        }
-
+        var response = await this.client.SendAsync(request);
 
         if (response.StatusCode == HttpStatusCode.NotFound)
             return null;


### PR DESCRIPTION
Hey there,

this is a tiny PR to remove ambiguity during parsing. Right now, it's impossible to know whether parsing failed or a character/fc/etc was not found. If the entity was not found, the method returns null. However, the method also returns null if certain exceptions were thrown.

I believe there is no reason to swallow exceptions at this point and it would be better practice to throw them instead. It's up to the user to handle the exceptions appropriately. This makes errors more transparent when using the parser, and removes the ambiguity between entity not found / parsing failed. It also allows setup of resilience pipelines to retry parsing in case of network/rate limit issues.