### PR TITLE
Fix Free Company recruitment query string

### DIFF
--- a/NetStone/Search/FreeCompany/Recruitment.cs
+++ b/NetStone/Search/FreeCompany/Recruitment.cs
@@ -8,15 +8,15 @@ public enum Recruitment
     /// <summary>
     /// Dot not filter by recruitment status
     /// </summary>
-    All,
+    All = 99,
 
     /// <summary>
     /// Filter for groups actively recruiting
     /// </summary>
-    Open,
+    Open = 1,
 
     /// <summary>
     /// Filter for groups not actively recruiting
     /// </summary>
-    Closed,
+    Closed = 0
 }


### PR DESCRIPTION
The "open" query parameter is 0 when recruitment is closed, and 1 when it's open. The enum did not reflect this and filtering by recruitment failed as a result. This is a small PR to fix the issue.