### PR TITLE
Add Facewear to CharacterGear

### DIFF
--- a/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
+++ b/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
@@ -144,6 +144,12 @@ public class CharacterGearDefinition : IDefinition
     /// </summary>
     [JsonProperty("FEET")]
     public GearEntryDefinition Feet { get; set; }
+    
+    /// <summary>
+    /// Facewear
+    /// </summary>
+    [JsonProperty("FACEWEAR")]
+    public GearEntryDefinition Facewear { get; set; }
 
     /// <summary>
     /// Earrings

--- a/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
+++ b/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
@@ -81,6 +81,30 @@ public class GearEntryDefinition
 }
 
 /// <summary>
+/// Definition for Facewear slot
+/// </summary>
+public class FacewearEntryDefinition
+{
+    /// <summary>
+    /// Name of the facewear
+    /// </summary>
+    [JsonProperty("NAME")]
+    public DefinitionsPack Name { get; set; }
+    
+    /// <summary>
+    /// Name of the item this facewear is unlocked by
+    /// </summary>
+    [JsonProperty("UNLOCKED_BY")]
+    public DefinitionsPack UnlockedBy { get; set; }
+    
+    /// <summary>
+    /// Link to Eorzea Database for facewear
+    /// </summary>
+    [JsonProperty("DB_LINK")]
+    public DefinitionsPack DbLink { get; set; }
+}
+
+/// <summary>
 /// Definition for Soul Crystal slot
 /// </summary>
 public class SoulcrystalEntryDefinition
@@ -149,7 +173,7 @@ public class CharacterGearDefinition : IDefinition
     /// Facewear
     /// </summary>
     [JsonProperty("FACEWEAR")]
-    public GearEntryDefinition Facewear { get; set; }
+    public FacewearEntryDefinition Facewear { get; set; }
 
     /// <summary>
     /// Earrings

--- a/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
+++ b/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
@@ -64,6 +64,11 @@ public class CharacterGear : LodestoneParseable
     public GearEntry? Feet => new GearEntry(this.client, this.RootNode, this.definition.Feet).GetOptional();
 
     /// <summary>
+    /// Information about the characters' facewear. Null if none equipped.
+    /// </summary>
+    public GearEntry? Facewear => new GearEntry(this.client, this.RootNode, this.definition.Facewear).GetOptional();
+
+    /// <summary>
     /// Information about the characters' earrings. Null if none equipped.
     /// </summary>
     public GearEntry? Earrings => new GearEntry(this.client, this.RootNode, this.definition.Earrings).GetOptional();

--- a/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
+++ b/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
@@ -66,7 +66,7 @@ public class CharacterGear : LodestoneParseable
     /// <summary>
     /// Information about the characters' facewear. Null if none equipped.
     /// </summary>
-    public GearEntry? Facewear => new GearEntry(this.client, this.RootNode, this.definition.Facewear).GetOptional();
+    public FacewearEntry? Facewear => new FacewearEntry(this.RootNode, this.definition.Facewear).GetOptional();
 
     /// <summary>
     /// Information about the characters' earrings. Null if none equipped.

--- a/NetStone/Model/Parseables/Character/Gear/FacewearEntry.cs
+++ b/NetStone/Model/Parseables/Character/Gear/FacewearEntry.cs
@@ -25,7 +25,7 @@ public class FacewearEntry : LodestoneParseable, IOptionalParseable<FacewearEntr
     /// <summary>
     /// Name of the item this facewear is unlocked by
     /// </summary>
-    public string? UnlockedBy => ParseAttribute(this.definition.UnlockedBy, "data-tooltip");
+    public string? UnlockedBy => ParseTooltip(this.definition.UnlockedBy);
 
     /// <summary>
     /// Link to this facewear's Eorzea DB page.

--- a/NetStone/Model/Parseables/Character/Gear/FacewearEntry.cs
+++ b/NetStone/Model/Parseables/Character/Gear/FacewearEntry.cs
@@ -1,0 +1,40 @@
+using System;
+using HtmlAgilityPack;
+using NetStone.Definitions.Model.Character;
+
+namespace NetStone.Model.Parseables.Character.Gear;
+
+/// <summary>
+/// Represents data about a character's facewear
+/// </summary>
+public class FacewearEntry : LodestoneParseable, IOptionalParseable<FacewearEntry>
+{
+    private readonly FacewearEntryDefinition definition;
+
+    ///<inheritdoc />
+    public FacewearEntry(HtmlNode rootNode, FacewearEntryDefinition definition) : base(rootNode)
+    {
+        this.definition = definition;
+    }
+
+    /// <summary>
+    /// Name of the facewear
+    /// </summary>
+    public string ItemName => Parse(this.definition.Name);
+    
+    /// <summary>
+    /// Name of the item this facewear is unlocked by
+    /// </summary>
+    public string? UnlockedBy => ParseAttribute(this.definition.UnlockedBy, "data-tooltip");
+
+    /// <summary>
+    /// Link to this facewear's Eorzea DB page.
+    /// </summary>
+    public Uri? DbLink => ParseHref(this.definition.DbLink);
+    
+    ///<inheritdoc />
+    public bool Exists => HasNode(this.definition.Name);
+    
+    ///<inheritdoc />
+    public override string ToString() => this.ItemName;
+}

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -843,6 +843,11 @@
             Feet
             </summary>
         </member>
+        <member name="P:NetStone.Definitions.Model.Character.CharacterGearDefinition.Facewear">
+            <summary>
+            Facewear
+            </summary>
+        </member>
         <member name="P:NetStone.Definitions.Model.Character.CharacterGearDefinition.Earrings">
             <summary>
             Earrings
@@ -2834,6 +2839,11 @@
         <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Feet">
             <summary>
             Information about the characters' shoes. Null if none equipped.
+            </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Facewear">
+            <summary>
+            Information about the characters' facewear. Null if none equipped.
             </summary>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Earrings">

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -788,6 +788,26 @@
             Item level of the item
             </summary>
         </member>
+        <member name="T:NetStone.Definitions.Model.Character.FacewearEntryDefinition">
+            <summary>
+            Definition for Facewear slot
+            </summary>
+        </member>
+        <member name="P:NetStone.Definitions.Model.Character.FacewearEntryDefinition.Name">
+            <summary>
+            Name of the facewear
+            </summary>
+        </member>
+        <member name="P:NetStone.Definitions.Model.Character.FacewearEntryDefinition.UnlockedBy">
+            <summary>
+            Name of the item this facewear is unlocked by
+            </summary>
+        </member>
+        <member name="P:NetStone.Definitions.Model.Character.FacewearEntryDefinition.DbLink">
+            <summary>
+            Link to Eorzea Database for facewear
+            </summary>
+        </member>
         <member name="T:NetStone.Definitions.Model.Character.SoulcrystalEntryDefinition">
             <summary>
             Definition for Soul Crystal slot
@@ -2875,6 +2895,35 @@
             <summary>
             Information about the characters' soul crystal. Null if none equipped.
             </summary>
+        </member>
+        <member name="T:NetStone.Model.Parseables.Character.Gear.FacewearEntry">
+            <summary>
+            Represents data about a character's facewear
+            </summary>
+        </member>
+        <member name="M:NetStone.Model.Parseables.Character.Gear.FacewearEntry.#ctor(HtmlAgilityPack.HtmlNode,NetStone.Definitions.Model.Character.FacewearEntryDefinition)">
+            <inheritdoc />
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.FacewearEntry.ItemName">
+            <summary>
+            Name of the facewear
+            </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.FacewearEntry.UnlockedBy">
+            <summary>
+            Name of the item this facewear is unlocked by
+            </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.FacewearEntry.DbLink">
+            <summary>
+            Link to this facewear's Eorzea DB page.
+            </summary>
+        </member>
+        <member name="P:NetStone.Model.Parseables.Character.Gear.FacewearEntry.Exists">
+            <inheritdoc />
+        </member>
+        <member name="M:NetStone.Model.Parseables.Character.Gear.FacewearEntry.ToString">
+            <inheritdoc />
         </member>
         <member name="T:NetStone.Model.Parseables.Character.Gear.GearEntry">
             <summary>


### PR DESCRIPTION
Add support for the new CSS selectors introduced in https://github.com/xivapi/lodestone-css-selectors/pull/32. With this, it's possible to read a characters' facewear, if equipped.