### PR TITLE
Remove Waist from CharacterGear

### DIFF
--- a/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
+++ b/NetStone/Definitions/Model/Character/CharacterGearDefinition.cs
@@ -128,12 +128,6 @@ public class CharacterGearDefinition : IDefinition
     public GearEntryDefinition Hands { get; set; }
 
     /// <summary>
-    /// Waist
-    /// </summary>
-    [JsonProperty("WAIST")]
-    public GearEntryDefinition Waist { get; set; }
-
-    /// <summary>
     /// Legs
     /// </summary>
     [JsonProperty("LEGS")]

--- a/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
+++ b/NetStone/Model/Parseables/Character/Gear/CharacterGear.cs
@@ -49,11 +49,6 @@ public class CharacterGear : LodestoneParseable
     public GearEntry? Hands => new GearEntry(this.client, this.RootNode, this.definition.Hands).GetOptional();
 
     /// <summary>
-    /// Information about the characters' waist gear. Null if none equipped.
-    /// </summary>
-    public GearEntry? Waist => new GearEntry(this.client, this.RootNode, this.definition.Waist).GetOptional();
-
-    /// <summary>
     /// Information about the characters' pants. Null if none equipped.
     /// </summary>
     public GearEntry? Legs => new GearEntry(this.client, this.RootNode, this.definition.Legs).GetOptional();

--- a/NetStone/NetStone.xml
+++ b/NetStone/NetStone.xml
@@ -828,11 +828,6 @@
             Hand piece
             </summary>
         </member>
-        <member name="P:NetStone.Definitions.Model.Character.CharacterGearDefinition.Waist">
-            <summary>
-            Waist
-            </summary>
-        </member>
         <member name="P:NetStone.Definitions.Model.Character.CharacterGearDefinition.Legs">
             <summary>
             Legs
@@ -2819,11 +2814,6 @@
         <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Hands">
             <summary>
             Information about the characters' gloves. Null if none equipped.
-            </summary>
-        </member>
-        <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Waist">
-            <summary>
-            Information about the characters' waist gear. Null if none equipped.
             </summary>
         </member>
         <member name="P:NetStone.Model.Parseables.Character.Gear.CharacterGear.Legs">


### PR DESCRIPTION
The game and Lodestone do not use the waist slot anymore, so it may be removed.